### PR TITLE
Generate Timestamp without the use of locale

### DIFF
--- a/warrant_lite/__init__.py
+++ b/warrant_lite/__init__.py
@@ -109,17 +109,17 @@ def temp_locale(new_locale):
     locale.setlocale(locale.LC_ALL, original)
 
 
-def timestamp_string():
+def timestamp_string(date):
     # re strips leading zero from a day number (required by AWS Cognito)
     try:
         with temp_locale(('en_US', 'utf-8')):
             return re.sub(r" 0(\d) ", r" \1 ",
-                        datetime.datetime.utcnow().strftime("%a %b %d %H:%M:%S UTC %Y"))
+                        date.strftime("%a %b %d %H:%M:%S UTC %Y"))
     except locale.Error:
         # try windows locale format
         with temp_locale(('English_United States', '1252')):
             return re.sub(r" 0(\d) ", r" \1 ",
-                        datetime.datetime.utcnow().strftime("%a %b %d %H:%M:%S UTC %Y"))
+                        date.strftime("%a %b %d %H:%M:%S UTC %Y"))
 
 
 class WarrantLite(object):
@@ -210,7 +210,7 @@ class WarrantLite(object):
         salt_hex = challenge_parameters['SALT']
         srp_b_hex = challenge_parameters['SRP_B']
         secret_block_b64 = challenge_parameters['SECRET_BLOCK']
-        timestamp = timestamp_string()
+        timestamp = timestamp_string(datetime.datetime.utcnow())
         hkdf = self.get_password_authentication_key(user_id_for_srp,
                                                     self.password, hex_to_long(srp_b_hex), salt_hex)
         secret_block_bytes = base64.standard_b64decode(secret_block_b64)

--- a/warrant_lite/__init__.py
+++ b/warrant_lite/__init__.py
@@ -1,11 +1,8 @@
 import base64
 import binascii
-import contextlib
 import datetime
 import hashlib
 import hmac
-import locale
-import re
 
 import boto3
 import os
@@ -102,13 +99,6 @@ def calculate_u(big_a, big_b):
     """
     u_hex_hash = hex_hash(pad_hex(big_a) + pad_hex(big_b))
     return hex_to_long(u_hex_hash)
-
-
-@contextlib.contextmanager
-def temp_locale(new_locale):
-    original = locale.getlocale()
-    yield locale.setlocale(locale.LC_ALL, new_locale)
-    locale.setlocale(locale.LC_ALL, original)
 
 
 def timestamp_string(date):

--- a/warrant_lite/__init__.py
+++ b/warrant_lite/__init__.py
@@ -36,6 +36,8 @@ n_hex = 'FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD1' + '29024E088A67CC7402
 g_hex = '2'
 info_bits = bytearray('Caldera Derived Key', 'utf-8')
 
+week_names = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+month_names = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
 
 def hash_sha256(buf):
     """AuthenticationHelper.hash"""
@@ -110,16 +112,19 @@ def temp_locale(new_locale):
 
 
 def timestamp_string(date):
-    # re strips leading zero from a day number (required by AWS Cognito)
-    try:
-        with temp_locale(('en_US', 'utf-8')):
-            return re.sub(r" 0(\d) ", r" \1 ",
-                        date.strftime("%a %b %d %H:%M:%S UTC %Y"))
-    except locale.Error:
-        # try windows locale format
-        with temp_locale(('English_United States', '1252')):
-            return re.sub(r" 0(\d) ", r" \1 ",
-                        date.strftime("%a %b %d %H:%M:%S UTC %Y"))
+    """
+    Generate a timestamp string for the current time in the following format:
+    Fri Oct 2 01:02:03 UTC 2020
+    """
+    return "%s %s %d %02d:%02d:%02d UTC %d" % (
+        week_names[date.weekday()],
+        month_names[date.month-1],
+        date.day,
+        date.hour,
+        date.minute,
+        date.second,
+        date.year
+    )
 
 
 class WarrantLite(object):

--- a/warrant_lite/tests.py
+++ b/warrant_lite/tests.py
@@ -1,8 +1,9 @@
+import datetime
 import unittest
 
 from envs import env
 
-from warrant_lite import WarrantLite, TokenVerificationException
+from warrant_lite import WarrantLite, TokenVerificationException, timestamp_string
 
 
 class WarrantLiteTestCase(unittest.TestCase):
@@ -39,6 +40,34 @@ class WarrantLiteTestCase(unittest.TestCase):
         self.assertTrue('AccessToken' in tokens['AuthenticationResult'])
         self.assertTrue('RefreshToken' in tokens['AuthenticationResult'])
 
+class TimestampStringTest(unittest.TestCase):
+
+    def test_when_no_padding_is_necessary_should_return(self):
+        date = datetime.datetime(2020, 10, 28, hour=16, minute=36,
+                                      second=17, microsecond=14,
+                                      tzinfo=datetime.timezone.utc)
+
+        actual = timestamp_string(date)
+
+        self.assertEqual("Wed Oct 28 16:36:17 UTC 2020", actual)
+
+    def test_should_pad_timestamp(self):
+        date = datetime.datetime(2020, 10, 28, hour=1, minute=2,
+                                      second=3, microsecond=4,
+                                      tzinfo=datetime.timezone.utc)
+
+        actual = timestamp_string(date)
+
+        self.assertEqual("Wed Oct 28 01:02:03 UTC 2020", actual)
+
+    def test_should_not_pad_day(self):
+        date = datetime.datetime(2020, 10, 2, hour=1, minute=2,
+                                      second=3, microsecond=4,
+                                      tzinfo=datetime.timezone.utc)
+
+        actual = timestamp_string(date)
+
+        self.assertEqual("Fri Oct 2 01:02:03 UTC 2020", actual)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hi :wave: 

I had an issue when using this module because some of my target systems do not have the `en_US` locale installed.
This issue also exists when using the python docker image, which also does not have this locale installed by default.

```
$ docker run --rm python:3.8.3 python -c "import locale; locale.setlocale(locale.LC_ALL, ('en_US', 'utf-8'))"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/local/lib/python3.8/locale.py", line 608, in setlocale
    return _setlocale(category, locale)
locale.Error: unsupported locale setting
```

As a workaround, I suggest to generate the timestamp manually. This is more portable and more explicit.
